### PR TITLE
Replaced registered trademark symbol with ASCII version

### DIFF
--- a/libvpl/pkgconfig/vpl.pc.in
+++ b/libvpl/pkgconfig/vpl.pc.in
@@ -2,8 +2,8 @@ prefix=@pc_rel_prefix@
 libdir=@pc_rel_libdir@
 includedir=@pc_rel_incdir@
 
-Name: Intel® Video Processing Library
-Description: Accelerated video decode, encode, and frame processing capabilities on Intel® GPUs
+Name: Intel(R) Video Processing Library
+Description: Accelerated video decode, encode, and frame processing capabilities on Intel(R) GPUs
 Version: @API_VERSION_MAJOR@.@API_VERSION_MINOR@
 URL: https://github.com/intel/libvpl
 


### PR DESCRIPTION
## Issue

The "®" was not conforming to [RFC-822](https://www.w3.org/Protocols/rfc822/#:~:text=3.2.%20HEADER%20FIELD%20DEFINITIONS) and broke downstream build tools; See https://github.com/haskell/cabal/issues/9608 for an example.

Fixes #117 

## Solution

Just replaced the symbol with `(R)`. This appears to be the go-to solution is also used by other packages, e.g. <https://github.com/intel/gmmlib/blob/f5943626a108245a31290811f41338e7151ac22d/Source/GmmLib/igdgmm.pc.in>.

## How Tested

Tested it locally by running a [Cabal](https://github.com/haskell/cabal) build which was failing before.
