### PR TITLE
Use only ASCII text in pkg-config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ portable media pipelines on CPUs, GPUs, and other accelerators.
 
 ## [Unreleased]
 
+### Fixed
+- "®" symbol in pkg-config file breaking downstream build tools
+
 ## [2.10.1] - 2023-12-22
 
 ### Added

--- a/libvpl/pkgconfig/vpl.pc.in
+++ b/libvpl/pkgconfig/vpl.pc.in
@@ -2,8 +2,8 @@ prefix=@pc_rel_prefix@
 libdir=@pc_rel_libdir@
 includedir=@pc_rel_incdir@
 
-Name: Intel® Video Processing Library
-Description: Accelerated video decode, encode, and frame processing capabilities on Intel® GPUs
+Name: Intel(R) Video Processing Library
+Description: Accelerated video decode, encode, and frame processing capabilities on Intel(R) GPUs
 Version: @API_VERSION_MAJOR@.@API_VERSION_MINOR@
 URL: https://github.com/intel/libvpl
 


### PR DESCRIPTION
## Issue
#117 "®" symbol in pkg-config file breaking downstream build tools

## Solution
Replace the symbol with `(R)`. 

Note this is being submitted in lieu of #118 because submitter did not make requested changes and several others requested the fixes be merged to unblock them.

## How Tested

internal CI and feedback from original submitter
