### PR TITLE
SMT fails to exit if encode is disabled and prolong is set

### DIFF
--- a/tools/legacy/sample_multi_transcode/src/pipeline_transcode.cpp
+++ b/tools/legacy/sample_multi_transcode/src/pipeline_transcode.cpp
@@ -1652,23 +1652,10 @@ mfxStatus CTranscodingPipeline::Encode() {
                         VppExtSurface.pSurface = 0;
                     }
                     sts = EncodeOneFrame(&VppExtSurface, &m_BSPool.back()->Bitstream);
-                    if (bAllBlackFrame && (1 == m_Prolonged)) {
-                        isQuit = true;
-                        if (m_nVPPCompMode > 0) {
-                            curBuffer->Prolong = AllBlack; //first thread
-                            while (curBuffer->m_pNext != NULL) {
-                                curBuffer = curBuffer->m_pNext;
-                                curBuffer->Prolong =
-                                    AllBlack; //indicate All Black detected for remaining thread
-                            }
-                        }
-                        curBuffer = m_pBuffer;
-                    }
 
                     // Count only real surfaces
                     if (VppExtSurface.pSurface) {
                         m_nProcessedFramesNum++;
-                        bAllBlackFrame = true; //reset value, default to true
                     }
 
                     if (m_nProcessedFramesNum >= m_MaxFramesForTranscode) {
@@ -1694,6 +1681,21 @@ mfxStatus CTranscodingPipeline::Encode() {
         {
             m_pBuffer->ReleaseSurface(DecExtSurface.pSurface);
         }
+
+        if (bAllBlackFrame && (1 == m_Prolonged)) {
+            isQuit = true;
+            if (m_nVPPCompMode > 0) {
+                curBuffer->Prolong = AllBlack; //first thread
+                while (curBuffer->m_pNext != NULL) {
+                    curBuffer = curBuffer->m_pNext;
+                    curBuffer->Prolong =
+                        AllBlack; //indicate All Black detected for remaining thread
+                }
+            }
+            curBuffer = m_pBuffer;
+        }
+
+        bAllBlackFrame = true;
 
         // check if we need one more frame from decode
         if (MFX_ERR_MORE_DATA == sts) {


### PR DESCRIPTION
## Issue
SMT will continuously decode and encode black frames once all videos finish playing.

Problematic par file is attached as pro4streams_not_able_to_exit.par

Issue is not seen if  -o::h265 outpuPR.out is added as part of the command

## Solution
Root cause: Sample_multi_transcode doesn't stop because bAllBlackFrame is only set in the case when video encoding option is specified. When we render without doing encoding, surfaces with black frames were continuously created by Decode(), thus the encoding never ends.

## How Tested
1) Ran pro4streams_not_able_to_exit.par (rename the txt file as par)
[pro4streams_not_able_exit.txt](https://github.com/intel/libvpl/files/14663045/pro4streams_not_able_exit.txt)
This file will perform rendering only.

2) Ran pro4streams_not_able_exit_NoRender.par
[pro4streams_not_able_exit_NoRender.txt](https://github.com/intel/libvpl/files/14663047/pro4streams_not_able_exit_NoRender.txt)
This file will only encode the output as outpuPR.out

3) Tested single stream. The behaviour before and after are the same
4) Tested when prolong = 0. The behaviour before and after are the same