### PR TITLE
Fix function 'StringFromGUID2' using an incorrect parameter

### DIFF
--- a/libvpl/src/windows/mfx_driver_store_loader.cpp
+++ b/libvpl/src/windows/mfx_driver_store_loader.cpp
@@ -68,7 +68,7 @@ bool DriverStoreLoader::GetDriverStorePath(wchar_t *path,
         return false;
     }
 
-    if (StringFromGUID2(GUID_DEVCLASS_DISPLAY, DisplayGUID, sizeof(DisplayGUID)) == 0) {
+    if (StringFromGUID2(GUID_DEVCLASS_DISPLAY, DisplayGUID, _countof(DisplayGUID)) == 0) {
         DISPATCHER_LOG_WRN(("Couldn't prepare string from GUID\n"));
         return false;
     }


### PR DESCRIPTION
## Issue

The third parameter of the function 'StringFromGUID2' is count of 'LPOLESTR' but not 'byte' size of buffer.
Using 'sizeof' here will cause a warning 'C6386'

## Solution

use '_countof' instead of 'sizeof'

## How Tested

Buffer size 40 with wchar type is enough, do not need test
