### PR TITLE
Delete useless include header on windows platform

### DIFF
--- a/libvpl/src/windows/main.cpp
+++ b/libvpl/src/windows/main.cpp
@@ -5,9 +5,6 @@
   ############################################################################*/
 
 #include <windows.h>
-
-#include <stringapiset.h>
-
 #include <memory>
 #include <new>
 


### PR DESCRIPTION
## Issue

libvpl do not use any function in header '<stringapiset.h>'，this header min supported version is 'Windows 2000 Professional'
(see https://learn.microsoft.com/en-us/windows/win32/api/stringapiset/nf-stringapiset-widechartomultibyte).

if we use a toolset 'v140_xp'， '<stringapiset.h>' will cause compile failed.


## Solution

Just delete this header

## How Tested

1、CMake with toolset 'v140_xp'，Compile successfully
2、CMake with toolset any，Compile successfully

Lint all passed this time ...
![image](https://github.com/intel/libvpl/assets/3795983/b75f0bc9-bafa-4975-9469-af0cedbb5f3e)
