### PR TITLE
Avoid repeated initialization of d3d9 or d3d11 devices to reduce mfxinit call time

### DIFF
--- a/libvpl/src/mfx_dispatcher_vpl_msdk.cpp
+++ b/libvpl/src/mfx_dispatcher_vpl_msdk.cpp
@@ -196,7 +196,7 @@ mfxStatus LoaderCtxMSDK::GetDefaultAccelType(mfxU32 adapterID, mfxIMPL *implDefa
 
     // check whether adapterID supports D3D11 and has correct VendorID
     implTest = MFX_IMPL_VIA_D3D11;
-    sts      = MFX::SelectImplementationType(adapterID, &implTest, &VendorID, &DeviceID, luid);
+    sts      = MFX::SelectImplementationType2(adapterID, &implTest, &VendorID, &DeviceID, luid);
 
     if (sts != MFX_ERR_NONE || VendorID != 0x8086) {
         implTest = MFX_IMPL_UNSUPPORTED;
@@ -446,7 +446,7 @@ mfxStatus LoaderCtxMSDK::CheckD3D9Support(mfxU64 luid, STRING_TYPE libNameFull, 
     mfxU32 idx;
     for (idx = 0; idx < MAX_NUM_IMPL_MSDK; idx++) {
         mfxU64 luidD3D9 = 0;
-        sts = MFX::SelectImplementationType(idx, &implTest, &VendorID, &DeviceID, &luidD3D9);
+        sts = MFX::SelectImplementationType2(idx, &implTest, &VendorID, &DeviceID, &luidD3D9);
 
         if (sts != MFX_ERR_NONE || VendorID != 0x8086 || luid != luidD3D9)
             continue;

--- a/libvpl/src/windows/main.cpp
+++ b/libvpl/src/windows/main.cpp
@@ -170,7 +170,9 @@ mfxStatus MFXInitEx(mfxInitParam par, mfxSession *session) {
 
     MFX_DISP_HANDLE_EX *pHandle;
     wchar_t dllName[MFX_MAX_DLL_PATH] = { 0 };
-    MFX::MFXLibraryIterator libIterator;
+
+    DXVA2Device dxvaDevice;
+    MFX::MFXLibraryIterator libIterator(dxvaDevice);
 
     // there iterators are used only if the caller specified implicit type like AUTO
     mfxU32 curImplIdx, maxImplIdx;
@@ -384,7 +386,8 @@ mfxStatus MFXInitEx(mfxInitParam par, mfxSession *session) {
                     implInterface = MFX_IMPL_VIA_ANY;
                 }
                 mfxU32 curVendorID = 0, curDeviceID = 0;
-                mfxRes = MFX::SelectImplementationType(implTypes[curImplIdx].adapterID,
+                mfxRes = MFX::SelectImplementationType(dxvaDevice,
+                                                       implTypes[curImplIdx].adapterID,
                                                        &implInterface,
                                                        &curVendorID,
                                                        &curDeviceID);

--- a/libvpl/src/windows/mfx_dxva2_device.h
+++ b/libvpl/src/windows/mfx_dxva2_device.h
@@ -169,7 +169,7 @@ public:
 protected:
 #ifdef MFX_D3D9_ENABLED
     // Get vendor & device IDs by alternative way (D3D9 in Remote Desktop sessions)
-    void UseAlternativeWay(const D3D9Device *pD3D9Device);
+    void UseAlternativeWay(const D3D9Device &pD3D9Device);
 #endif // MFX_D3D9_ENABLED
     // Number of adapters available
     mfxU32 m_numAdapters;
@@ -182,6 +182,10 @@ protected:
     mfxU64 m_driverVersion;
     // LUID
     mfxU64 m_luid;
+    // D3D9 Device
+    D3D9Device m_d3d9Device;
+    // DXGI Device
+    DXGI1Device m_dxgi1Device;
 
 private:
     // unimplemented by intent to make this class non-copyable

--- a/libvpl/src/windows/mfx_library_iterator.h
+++ b/libvpl/src/windows/mfx_library_iterator.h
@@ -17,6 +17,7 @@
 
 #include "src/windows/mfx_dispatcher.h"
 #include "src/windows/mfx_driver_store_loader.h"
+#include "src/windows/mfx_dxva2_device.h"
 
 namespace MFX {
 
@@ -50,16 +51,24 @@ enum {
 
 // Try to initialize using given implementation type. Select appropriate type automatically in case of MFX_IMPL_VIA_ANY.
 // Params: adapterNum - in, pImplInterface - in/out, pVendorID - out, pDeviceID - out, pLUID - out (optional)
-mfxStatus SelectImplementationType(const mfxU32 adapterNum,
+mfxStatus SelectImplementationType(DXVA2Device &dxvaDevice,
+                                   const mfxU32 adapterNum,
                                    mfxIMPL *pImplInterface,
                                    mfxU32 *pVendorID,
                                    mfxU32 *pDeviceID);
 
-mfxStatus SelectImplementationType(const mfxU32 adapterNum,
+mfxStatus SelectImplementationType(DXVA2Device &dxvaDevice,
+                                   const mfxU32 adapterNum,
                                    mfxIMPL *pImplInterface,
                                    mfxU32 *pVendorID,
                                    mfxU32 *pDeviceID,
                                    mfxU64 *pLUID);
+
+mfxStatus SelectImplementationType2(const mfxU32 adapterNum,
+                                    mfxIMPL *pImplInterface,
+                                    mfxU32 *pVendorID,
+                                    mfxU32 *pDeviceID,
+                                    mfxU64 *pLUID);
 
 bool GetImplPath(int storageID, wchar_t *sImplPath);
 
@@ -68,7 +77,7 @@ const mfxU32 msdk_disp_path_len = 1024;
 class MFXLibraryIterator {
 public:
     // Default constructor
-    MFXLibraryIterator(void);
+    explicit MFXLibraryIterator(DXVA2Device &dxvaDevice);
     // Destructor
     ~MFXLibraryIterator(void);
 
@@ -133,6 +142,8 @@ protected:
     wchar_t m_driverStoreDir[msdk_disp_path_len]; //NOLINT(runtime/arrays)
 
     DriverStoreLoader m_driverStoreLoader; // for loading MediaSDK from DriverStore
+
+    DXVA2Device &m_dxvaDevice; // for getting d3d9 or d3d11 information
 
 private:
     // unimplemented by intent to make this class non-copyable

--- a/libvpl/test/diagnostic/CMakeLists.txt
+++ b/libvpl/test/diagnostic/CMakeLists.txt
@@ -5,4 +5,5 @@
 # ##############################################################################
 
 add_subdirectory(mfxinit-test)
+add_subdirectory(mfxinit-timing)
 add_subdirectory(vpl-timing)

--- a/libvpl/test/diagnostic/mfxinit-timing/CMakeLists.txt
+++ b/libvpl/test/diagnostic/mfxinit-timing/CMakeLists.txt
@@ -1,0 +1,16 @@
+# ##############################################################################
+# Copyright (C) Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+# ##############################################################################
+cmake_minimum_required(VERSION 3.13.0)
+
+if(MSVC)
+  add_definitions(-D_CRT_SECURE_NO_WARNINGS)
+endif()
+
+add_executable(mfxinit-timing main.cpp)
+target_link_libraries(mfxinit-timing VPL)
+target_include_directories(mfxinit-timing
+                           PRIVATE ${ONEVPL_API_HEADER_DIRECTORY})
+target_compile_definitions(${TARGET} PUBLIC -DMFX_DEPRECATED_OFF)

--- a/libvpl/test/diagnostic/mfxinit-timing/main.cpp
+++ b/libvpl/test/diagnostic/mfxinit-timing/main.cpp
@@ -1,0 +1,69 @@
+/*############################################################################
+  # Copyright (C) Intel Corporation
+  #
+  # SPDX-License-Identifier: MIT
+  ############################################################################*/
+
+#include <chrono>
+#include <cinttypes>
+
+#include "vpl/mfx.h"
+
+#define ARRAY_SIZE(a) sizeof(a) / sizeof(a[0])
+
+typedef std::chrono::high_resolution_clock HRC;
+static uint64_t time_point_diff(HRC::time_point &s, HRC::time_point &e) {
+    std::chrono::microseconds diff = std::chrono::duration_cast<std::chrono::microseconds>(e - s);
+    return diff.count();
+}
+
+typedef struct key_name_pair_s {
+    int key;
+    const char *name;
+} key_name_pair_t;
+
+static const key_name_pair_t implPairs[] = {
+    { MFX_IMPL_HARDWARE_ANY, "MFX_IMPL_HARDWARE_ANY" },
+    { MFX_IMPL_HARDWARE, "MFX_IMPL_HARDWARE" },
+    { MFX_IMPL_HARDWARE2, "MFX_IMPL_HARDWARE2" },
+    { MFX_IMPL_HARDWARE3, "MFX_IMPL_HARDWARE3" },
+    { MFX_IMPL_HARDWARE4, "MFX_IMPL_HARDWARE4" },
+};
+
+static const key_name_pair_t viaPairs[] = {
+    { MFX_IMPL_VIA_ANY, "MFX_IMPL_VIA_ANY" },
+    { MFX_IMPL_VIA_D3D9, "MFX_IMPL_VIA_D3D9" },
+    { MFX_IMPL_VIA_D3D11, "MFX_IMPL_VIA_D3D11" },
+};
+
+int main(int argc, char *argv[]) {
+    mfxStatus sts  = MFX_ERR_NONE;
+    mfxVersion ver = { 1, 0 };
+    for (size_t i = 0; i < ARRAY_SIZE(implPairs); ++i) {
+        const key_name_pair_t *implPair = &implPairs[i];
+        for (size_t j = 0; j < ARRAY_SIZE(viaPairs); ++j) {
+            const key_name_pair_t *viaPair = &viaPairs[j];
+
+            mfxSession session;
+            HRC::time_point startTime = HRC::now();
+            sts                       = MFXInit(implPair->key | viaPair->key, &ver, &session);
+            HRC::time_point endTime   = HRC::now();
+
+            uint64_t time_diff = time_point_diff(startTime, endTime);
+            fprintf(stdout,
+                    "mfxinit-timing  -- %25s | %-25s sts %3d  -- cost %" PRIu64 " ms\n",
+                    implPair->name,
+                    viaPair->name,
+                    sts,
+                    time_diff / 1000);
+
+            if (session) {
+                MFXClose(session);
+            }
+        }
+    }
+
+    printf("Finished\n");
+
+    return 0;
+}


### PR DESCRIPTION
## Issue

Calling the mfxInit function is too time-consuming. We can even monitor in the production environment that calling mfxinit takes more than ten seconds.

I have carefully reviewed the code of libvpl and added a lot of testing code. There are several time-consuming areas:

**1. Repeated reinitialization of d3d devices**

Every time the MFX:: MFXLibraryIterator:: Init function is called, it will reinitialize the d3d device, which is quite time-consuming, especially for d3d9, where single creation is time-consuming, which is also a key time-consuming aspect. The entire mfxinit process seems to have a lot of room for optimization, but adjusting the entire process is quite complex. Simply adjust the d3d initialization process first, and optimizing here can greatly reduce the calling time of mfxinit

**2. MFXVideoCORE_QueryPlatform**

Without code, it is unclear why this function is time-consuming. Perhaps we can skip calling this function. Since only one libmfxhw32/64.9ll has been found, if hardware encoding and decoding are not supported, the final calling 'mfxInit' will eventually fail ?

**Why do we need to optimize the time consumption of mfxInit**

1. For many RTC scenarios, mfx initialization is too time-consuming and affects the entire program processing, making it longer. For example, for 1V1 video calls, using mfx for encoding and decoding means that both parties need a long time to see each other

2. The initialization of MFX is too time-consuming, which makes it difficult to handle and requires a lot of code to adapt to this time-consuming scenario. For example, we need to place the initialization process on an independent thread. If there are other modules that rely on MFX initialization to complete, we need to wait for the thread to end

## Solution
**1. All Library Iterator process use only one 'Dxva2Device'**

How：
step 1：Optimized DXVA2Device class
       1.1 Add two protected members  **'D3D9Device m_d3d9Device'** and **'DXGI1Device m_dxgi1Device'** for 'InitD3D9' and 'InitDXGI1' function
       1.2 For d3d9,  dynamic call 'Direct3DCreate9' only once while m_pD3D9 was not initialized
       1.3 For dxgi,  same as d3d9

step 2：Since MFXLibraryIterator should need 'DXVA2Device ' instance to do some worker,  we add as constructor parameter

step 3：In function "MFXInitEx", add variable 'DXVA2Device dxvaDevice', used by object 'libIterator' and function 'MFX::SelectImplementationType' as parameter

step 4：
In addition，This optimization only for leagacy mfxInit，I add function 'SelectImplementationType2' with C style name only used by 'mfx_dispatcher_vpl_msdk.cpp' to avoid affect vpl functions.


**2. New VPL interface also has this problem**

We did not use the new interface of VPL. In order to avoid affecting the functionality of VPL, this optimization does not affect the interface of VPL. We will migrate to the VPL interface as a whole and then synchronize the modifications to the interface code of VPL
![image](https://github.com/intel/libvpl/assets/3795983/54795b3c-6459-4cd2-bd4b-8be5010911cd)


## How Tested

**1. Local test**

I wrote a test case that used different combinations of IMPL and VIA to call the mfxInit function, and counted the time spent before and after the call. I randomly ran the old and optimized versions multiple times on my device. Below are the comparison results of two random runs, sts is the result returned by mfxInit, and cost is the time spent calling mfxInit The optimized version significantly reduces the time consumption of mfxInit

my device ：
cpu : ' Intel(R) Core(TM) i9-14900HX' 
intel driver version : 31.0.101.4577

1.1 Optimized version
rand 1
![image](https://github.com/intel/libvpl/assets/3795983/eb90b2b1-2bee-4db7-9f4d-a441e3ee83b0)
rand 2
![image](https://github.com/intel/libvpl/assets/3795983/5a47a57e-086d-4580-9c57-50c74e4e5cd9)

1.2 Old version
rand 1
![image](https://github.com/intel/libvpl/assets/3795983/d56b598e-f4a5-4ebe-a18c-e60693d848d7)
rand 2
![image](https://github.com/intel/libvpl/assets/3795983/1501604b-3a71-47b3-a785-c6ea2540e084)

**2. The effectiveness of our app verified in the production environment**

This modification has been validated in the production environment through our app and has been running for over 4 months on over 10 million devices. The modification runs well in the production environment without any large-scale problem feedback