### PR TITLE
fix potential exception

### DIFF
--- a/libvpl/src/mfx_dispatcher_vpl_loader.cpp
+++ b/libvpl/src/mfx_dispatcher_vpl_loader.cpp
@@ -208,7 +208,7 @@ mfxStatus LoaderCtxVPL::SearchDirForLibs(STRING_TYPE searchDir,
                 if (libFound != libInfoList.end())
                     continue;
 
-                LibInfo *libInfo = new LibInfo;
+                LibInfo *libInfo = new (std::nothrow) LibInfo;
                 if (!libInfo)
                     return MFX_ERR_MEMORY_ALLOC;
 
@@ -271,7 +271,7 @@ mfxStatus LoaderCtxVPL::SearchDirForLibs(STRING_TYPE searchDir,
                     continue;
                 }
 
-                LibInfo *libInfo = new LibInfo;
+                LibInfo *libInfo = new (std::nothrow) LibInfo;
                 if (!libInfo)
                     return MFX_ERR_MEMORY_ALLOC;
 
@@ -992,7 +992,7 @@ mfxStatus LoaderCtxVPL::QueryLibraryCaps() {
             UpdateImplPath(libInfo);
 
             for (mfxU32 i = 0; i < numImpls; i++) {
-                ImplInfo *implInfo = new ImplInfo;
+                ImplInfo *implInfo = new (std::nothrow) ImplInfo;
                 if (!implInfo)
                     return MFX_ERR_MEMORY_ALLOC;
 
@@ -1128,7 +1128,7 @@ mfxStatus LoaderCtxVPL::QueryLibraryCaps() {
                     msdkCtx->m_msdkAdapterD3D9 = msdkImplTab[i];
                 }
 
-                ImplInfo *implInfo = new ImplInfo;
+                ImplInfo *implInfo = new (std::nothrow) ImplInfo;
                 if (!implInfo)
                     return MFX_ERR_MEMORY_ALLOC;
 

--- a/libvpl/src/mfx_dispatcher_vpl_lowlatency.cpp
+++ b/libvpl/src/mfx_dispatcher_vpl_lowlatency.cpp
@@ -77,7 +77,7 @@ LibInfo *LoaderCtxVPL::AddSingleLibrary(STRING_TYPE libPath, LibType libType) {
 #endif
 
     // create new LibInfo and add to list
-    libInfo = new LibInfo;
+    libInfo = new (std::nothrow) LibInfo;
     if (!libInfo)
         return nullptr;
 


### PR DESCRIPTION
## Issue

If we want to determine memory allocation result，we should use new(std::nothrow) instead of new，because new failed will throw std::bad_alloc exception.  It may cause potential exception since modified code path does not have any try catch.

## Solution

Use new(std::nothrow) instead of new

## How Tested

Compile successfully is ok
