### PR TITLE
Fix potential exception and resource leak

### DIFF
--- a/libvpl/src/mfx_dispatcher_vpl_loader.cpp
+++ b/libvpl/src/mfx_dispatcher_vpl_loader.cpp
@@ -208,9 +208,11 @@ mfxStatus LoaderCtxVPL::SearchDirForLibs(STRING_TYPE searchDir,
                 if (libFound != libInfoList.end())
                     continue;
 
-                LibInfo *libInfo = new LibInfo;
-                if (!libInfo)
+                LibInfo *libInfo = new (std::nothrow) LibInfo;
+                if (!libInfo) {
+                    FindClose(hTestFile);
                     return MFX_ERR_MEMORY_ALLOC;
+                }
 
                 libInfo->libNameFull = libNameFull;
                 libInfo->libPriority = priority;
@@ -271,9 +273,11 @@ mfxStatus LoaderCtxVPL::SearchDirForLibs(STRING_TYPE searchDir,
                     continue;
                 }
 
-                LibInfo *libInfo = new LibInfo;
-                if (!libInfo)
+                LibInfo *libInfo = new (std::nothrow) LibInfo;
+                if (!libInfo) {
+                    closedir(pSearchDir);
                     return MFX_ERR_MEMORY_ALLOC;
+                }
 
                 libInfo->libNameFull = fullPath;
                 libInfo->libPriority = priority;
@@ -992,7 +996,7 @@ mfxStatus LoaderCtxVPL::QueryLibraryCaps() {
             UpdateImplPath(libInfo);
 
             for (mfxU32 i = 0; i < numImpls; i++) {
-                ImplInfo *implInfo = new ImplInfo;
+                ImplInfo *implInfo = new (std::nothrow) ImplInfo;
                 if (!implInfo)
                     return MFX_ERR_MEMORY_ALLOC;
 
@@ -1128,7 +1132,7 @@ mfxStatus LoaderCtxVPL::QueryLibraryCaps() {
                     msdkCtx->m_msdkAdapterD3D9 = msdkImplTab[i];
                 }
 
-                ImplInfo *implInfo = new ImplInfo;
+                ImplInfo *implInfo = new (std::nothrow) ImplInfo;
                 if (!implInfo)
                     return MFX_ERR_MEMORY_ALLOC;
 

--- a/libvpl/src/mfx_dispatcher_vpl_lowlatency.cpp
+++ b/libvpl/src/mfx_dispatcher_vpl_lowlatency.cpp
@@ -77,7 +77,7 @@ LibInfo *LoaderCtxVPL::AddSingleLibrary(STRING_TYPE libPath, LibType libType) {
 #endif
 
     // create new LibInfo and add to list
-    libInfo = new LibInfo;
+    libInfo = new (std::nothrow) LibInfo;
     if (!libInfo)
         return nullptr;
 


### PR DESCRIPTION
## Issue

1. If we want to determine memory allocation result，we should use **'new(std::nothrow)'** instead of new，because **'new'** failed will throw **'std::bad_alloc'** exception.  It may cause potential exception since modified code path does not have any try catch.

2. The original code can cause resource leak if just return 'MFX_ERR_MEMORY_ALLOC', see **libvpl/src/mfx_dispatcher_vpl_loader.cpp:line 211，276**

## Solution

1. Use **'new(std::nothrow)'** instead of **'new'**
2. Free resouce before return 'MFX_ERR_MEMORY_ALLOC'

## How Tested
1. **libvpl/src/mfx_dispatcher_vpl_loader.cpp:line 211，276**
1.1 set **'LibInfo *libInfo = nullptr'**  (If no memory，new (std::nothrow) will return nullptr)
1.2 run **vpl-timing** with argument **'-e'** ( run **'MFXEnumImplementations '** function)
1.3 MFXEnumImplementations return 'MFX_ERR_NOT_FOUND'，No memory leak，No crash，it is what we desired

2. libvpl/src/mfx_dispatcher_vpl_lowlatency.cpp:line 80