### PR TITLE
Distribution and privileges check

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -12,6 +12,10 @@
 
 set -o errexit
 
+if [ ! $(whoami) == "root" ]; then
+  echo "You need superuser privileges to continue."
+fi
+
 if [ -f "/etc/os-release" ]; then
   . /etc/os-release
 fi

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -19,6 +19,9 @@ fi
 if [ -f "/etc/os-release" ]; then
   . /etc/os-release
 fi
+if [ -n "$ID" ]; then
+  ID_LIKE=$ID
+fi
 if [ "$ID_LIKE" == "debian" ]; then
   apt-get update
   # basic build tools


### PR DESCRIPTION
## Issue

I saw that it was necessary to check another variable for the version of the Debian distribution that I am using, Bullseye. As well as whether the user has privilege to install a package using apt.

#144 - Problems identifying the linux distribution
#145 - Check root privileges

## Solution

About #144, to solve the distribution check, it is necessary to search for the ID variable instead of the ID_LIKE, then include a check for the existence of the ID variable and later, include it in the ID_LIKE variable.

#145, a quick check with the whoami command, to validate if the user is root

## How Tested

Just run the bootstrap script on Debian Bullseye
