### PR TITLE
FIX: bootstrap: when on debian OS itself, variable ID_LIKE does not exist.

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -15,6 +15,9 @@ set -o errexit
 if [ -f "/etc/os-release" ]; then
   . /etc/os-release
 fi
+if [ -z "$ID_LIKE" ]; then
+  ID_LIKE="$ID"
+fi
 if [ "$ID_LIKE" == "debian" ]; then
   apt-get update
   # basic build tools

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -157,4 +157,4 @@ else
 fi
 
 # lint dependencies
-pip3 install pre-commit
+pipx install pre-commit


### PR DESCRIPTION
## Issue
Bootstrap's OS detection was not successful on generic debian system.
Debian derivatives, like ubuntu expose $ID_LIKE variable via /etc/os-release.

## Solution

Additional check for $ID_LIKE variable, in cases where does not exists, it should use $ID.

## How Tested

Was trying to build on a debian(bullseye/bookwork) and this simple fix solved it.
