### PR TITLE
api: vpl: fix RGB565 documentation

### DIFF
--- a/api/vpl/mfxstructures.h
+++ b/api/vpl/mfxstructures.h
@@ -137,7 +137,7 @@ enum {
     MFX_FOURCC_YV12         = MFX_MAKEFOURCC('Y','V','1','2'),   /*!< YV12 color planes. */
     MFX_FOURCC_NV16         = MFX_MAKEFOURCC('N','V','1','6'),   /*!< 4:2:2 color format with similar to NV12 layout. */
     MFX_FOURCC_YUY2         = MFX_MAKEFOURCC('Y','U','Y','2'),   /*!< YUY2 color planes. */
-    MFX_FOURCC_RGB565       = MFX_MAKEFOURCC('R','G','B','2'),   /*!< 2 bytes per pixel, uint16 in little-endian format, where 0-4 bits are blue, bits 5-10 are green and bits 11-15 are red. */
+    MFX_FOURCC_RGB565       = MFX_MAKEFOURCC('R','G','B','2'),   /*!< 2 bytes per pixel, uint16 in little-endian format, where 0-4 bits are red, bits 5-10 are green and bits 11-15 are blue. */
     /*! RGB 24 bit planar layout (3 separate channels, 8-bits per sample each). This format should be mapped to D3DFMT_R8G8B8 or VA_FOURCC_RGBP. */
     MFX_FOURCC_RGBP         = MFX_MAKEFOURCC('R','G','B','P'),
     MFX_DEPRECATED_ENUM_FIELD_INSIDE(MFX_FOURCC_RGB3)         = MFX_MAKEFOURCC('R','G','B','3'),   /* Deprecated. */


### PR DESCRIPTION
According to libav, RGB565 first bit `(1 << 0)` is the least significant bit of Red. Adjust the documentation accordingly.

## Issue

The RGB565 was not documenting the same thing as `libav`. [EDIT: and libav test source might be wrong]

## Solution

~~Swap the red and blue channel in the documentation of RGB565 bits.~~

## How Tested

I observed the way `libav` fills the R, G and B value in a simple software [pattern generator](https://github.com/libav/libav/blob/c4642788e83b0858bca449f9b6e71ddb015dfa5d/libavfilter/vsrc_testsrc.c#L403).

~~This LWN article also shows a decoding of the RGB564 (little endian) format:
https://lwn.net/Articles/218798/ (the position of the most significant bit is insightful)~~

~~[This discussion](https://github.com/zephyrproject-rtos/zephyr/pull/79996#issuecomment-2438279540) is where the issue was discovered.~~

In hope this helps!