### PR TITLE
CMake: depend on libc++ when compiling with Clang

### DIFF
--- a/libvpl/CMakeLists.txt
+++ b/libvpl/CMakeLists.txt
@@ -190,7 +190,9 @@ if(INSTALL_DEV)
     # WIN32 in general
     set(MINGW_LIBS "-lole32 -lgdi32 -luuid")
   endif()
-  if(NOT MSVC)
+  if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    set(CXX_LIB "-lc++")
+  elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     set(CXX_LIB "-lstdc++")
   endif()
   set(VPL_PKGCONFIG_DEPENDENT_LIBS


### PR DESCRIPTION
libstdc++ is a GCC thing.

## Issue

When compiling with llvm-mingw the .pc file references `-lstdc++` which doesn't exist as it's a GCC thing.


## Solution

CMake can tell which compiler is used.

Rather than hardcoding thing it might be better to just use `CMAKE_CXX_IMPLICIT_LINK_LIBRARIES`: https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_IMPLICIT_LINK_LIBRARIES.html
